### PR TITLE
Add snapshot manifest and tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,35 +14,23 @@ on:
 
 jobs:
   build:
-
+    strategy:
+      matrix:
+        include:
+        - manifest: default.xml
+        - manifest: snapshot.xml
     runs-on: ubuntu-20.04
-
     steps:
-
     - name: Install apt-get packages
       run: |
         sudo ACCEPT_EULA=Y apt-get update
         sudo ACCEPT_EULA=Y apt-get upgrade
         sudo ACCEPT_EULA=Y apt-get install git wget sudo zip
-
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-
-    - name: Build
+    - name: Build ${{ matrix.manifest }}
+      env:
+        MANIFEST: ${{ matrix.manifest }}
       run: |
         bash ./build.sh
-
-    - name: Zip
-      run: |
-        zip -r sel4_wasmedge.zip sel4_wasmedge/build
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: sel4_wasmedge
-        path: sel4_wasmedge.zip
-
-        #- name: Simulate
-        #  run: |
-        #    cd sel4_wasmedge/build
-        #    ./simulate

--- a/README.md
+++ b/README.md
@@ -80,6 +80,27 @@ Run the edited `build.sh file.
 
 Once this manual installation is complete, follow along with the following steps; boot wasmedge-sel4
 
+### Use our pre-built binary
+
+If you want to do a quick test on wasmedge-seL4, you could try our pre-built binary:
+
+```bash
+mkdir build
+cd build
+wget https://github.com/second-state/wasmedge-seL4/releases/download/0.0.1/wasmedge-seL4-0.0.1-build.tar.gz
+tar zxvf wasmedge-seL4-0.0.1-build.tar.gz
+```
+
+You'll get the following pre-built files:
+
+```
+build/
+|-- images/
+|   `-- capdl-loader-image-arm-qemu-arm-virt
+|-- simulate
+`-- wasmedge-seL4-0.0.1-build.tar.gz
+```
+
 ### Boot wasmedge-seL4
 
 ```bash

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,12 @@ cd sel4_wasmedge
 
 # Setup project files
 git clone --branch v1.13.11 https://gerrit.googlesource.com/git-repo .repo/repo
-.repo/repo/repo init -b main -u https://github.com/second-state/wasmedge-seL4.git
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  git branch "$GITHUB_REF_NAME"
+  .repo/repo/repo init -b "$GITHUB_REF_NAME" -m "$MANIFEST" -u ..
+else
+  .repo/repo/repo init -b main -u https://github.com/second-state/wasmedge-seL4.git
+fi
 
 # Update and checkout files
 .repo/repo/repo sync

--- a/default.xml
+++ b/default.xml
@@ -9,7 +9,7 @@
   <remote name="lwip" fetch="https://git.savannah.gnu.org/git/"/>
   <remote name="picotcp" fetch="https://github.com/tass-belgium"/>
   <remote name="polly" fetch="https://github.com/ruslo"/>
-  <remote name="seL4" fetch="../seL4"/>
+  <remote name="seL4" fetch="https://github.com/seL4"/>
   <remote name="zeromq" fetch="https://github.com/zeromq"/>
   <remote name="llvm" fetch="https://github.com/llvm"/>
   <remote name="wasmedge" fetch="https://github.com/WasmEdge"/>

--- a/snapshot.xml
+++ b/snapshot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="second-state" fetch="https://github.com/second-state/"/>
+  <default remote="second-state" revision="main"/>
+  <project name="wasmedge-seL4-projects.git" path="." remote="second-state" revision="refs/tags/0.0.1" upstream="main" dest-branch="main"/>
+</manifest>


### PR DESCRIPTION
- Add `snaphost.xml` to fetch dependencies from own repository.
- Add instructions to use our pre-built binary.
- Add tests to use local manifest files on CI.